### PR TITLE
Prevent grabbing cookies that end in `name`

### DIFF
--- a/cookie-getter.js
+++ b/cookie-getter.js
@@ -1,7 +1,7 @@
 // simple commonJS cookie reader, best perf according to http://jsperf.com/cookie-parsing
 module.exports = function (name) {
     var cookie = document.cookie,
-        setPos = cookie.indexOf(name + '='),
+        setPos = cookie.search(new RegExp('\\b' + name + '=')),
         stopPos = cookie.indexOf(';', setPos),
         res;
     if (!~setPos) return null;


### PR DESCRIPTION
The previous code will only get the first cookie that ends in `name`, because it uses the `indexOf` function. Instead, the desired function is that we only return a cookie with the _exact_ name of `name`.

This regular expression will ensure we only find the "whole word" expression followed by some value instead of just the first cookie ending in `name`.

**Example**

```
Cookie: myconfig=["val1", "val2"]; config=["val3", "val4", "val5"]
```

```
var cookieGetter = require('cookie-getter'),
      cookie = cookieGetter('config');

console.log(cookie);
```

```
Output before change:  myconfig=["val1", "val2"]
```

```
Output after change: config=["val3", "val4", "val5"]
```
