### PR TITLE
Add support on Express JSON cookies (j: prefix)

### DIFF
--- a/cookie-getter.js
+++ b/cookie-getter.js
@@ -7,5 +7,5 @@ module.exports = function (name) {
   var res
   if (!~setPos) return null
   res = decodeURIComponent(cookie.substring(setPos, ~stopPos ? stopPos : undefined).split('=')[1])
-  return (res.charAt(0) === '{') ? JSON.parse(res) : res
+  return (res.charAt(0) === '{') ? JSON.parse(res) : ((res.indexOf('j:{') === 0) ? JSON.parse(res.substr(2)) : res)
 }

--- a/cookie-getter.js
+++ b/cookie-getter.js
@@ -7,5 +7,10 @@ module.exports = function (name) {
   var res
   if (!~setPos) return null
   res = decodeURIComponent(cookie.substring(setPos, ~stopPos ? stopPos : undefined).split('=')[1])
-  return (res.charAt(0) === '{') ? JSON.parse(res) : ((res.indexOf('j:{') === 0) ? JSON.parse(res.substr(2)) : res)
+  if (res.charAt(0) === '{') {
+    return JSON.parse(res)
+  } else if (res.indexOf('j:{') === 0) {
+    return JSON.parse(res.substr(2))
+  }
+  return res
 }

--- a/test/index.js
+++ b/test/index.js
@@ -23,3 +23,17 @@ test('parsing cookies separated by spaces', function (t) {
   document.cookie = 'name1=val1; name2=val2; name3=val3'
   t.equal(cookies('name2'), 'val2')
 })
+
+test('parsing JSON cookies', function (t) {
+  t.plan(2)
+  document.cookie = 'obj=%7B%22foo%22%3A%22bar%22%7D'
+  t.equal(typeof cookies('obj'), 'object')
+  t.equal(cookies('obj').foo, 'bar')
+})
+
+test('parsing Express JSON cookies', function (t) {
+  t.plan(2)
+  document.cookie = 'obj=j%3A%7B%22foo%22%3A%22bar%22%7D'
+  t.equal(typeof cookies('obj'), 'object')
+  t.equal(cookies('obj').foo, 'bar')
+})


### PR DESCRIPTION
Support decoding JSON objects in cookies retrieved from Express.js server (Express add prefix `j:` to stringified JSON: [Why setting object as cookie value get modified](https://github.com/expressjs/express/issues/2815)). 